### PR TITLE
Introducing `DomainConfigProvider`

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -46,6 +46,12 @@
 			"path": false,
 			"description": "Stores per domain configuration",
 			"descriptionmsg": "ldapprovider-config-domainconfigs"
+		},
+		"DomainConfigProvider": {
+			"value": "\\MediaWiki\\Extension\\LDAPProvider\\DomainConfigProvider\\LocalJSONFile::newInstance",
+			"public": false,
+			"description": "Specifies the mechanism for obtaining the domain configuration",
+			"descriptionmsg": "ldapprovider-config-domainconfigprovider"
 		}
 	},
 	"ConfigRegistry": {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -8,5 +8,6 @@
 	"ldapprovider-config-clientregistry": "Allows registration of custom clients",
 	"ldapprovider-config-domainconfigs": "Stores per domain configs",
 	"ldapprovider-domain-config-not-found": "\n\nCould not access configuration file '$1'!\n\nPlease set up a domain configuration file for the LDAPProvider extension.\n",
-	"ldapprovider-more-than-one": "Found more than one usef for '$1'"
+	"ldapprovider-more-than-one": "Found more than one usef for '$1'",
+	"ldapprovider-config-domainconfigprovider": "Specifies the mechanism for obtaining the domain configuration"
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -6,5 +6,6 @@
 	},
 	"ldapprovider-desc": "{{desc|name=LDAPProvider|url=https://www.mediawiki.org/wiki/Extension:LDAPProvider}}",
 	"ldapprovider-config-clientregistry": "Description of the configuration variable that allows registration of custom clients",
-	"ldapprovider-config-domainconfigs": "Description of the configuration variable that stores per domain configs"
+	"ldapprovider-config-domainconfigs": "Description of the configuration variable that stores per domain configs",
+	"ldapprovider-config-domainconfigprovider": "Description of the configuration variable that specifies the mechanism for obtaining the domain configuration"
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -10,6 +10,7 @@ class Config extends GlobalVarConfig {
 	const DOMAIN_CONFIGS = 'DomainConfigs';
 	const CACHE_TYPE = 'CacheType';
 	const CACHE_TIME = 'CacheTime';
+	const DOMAIN_CONFIG_PROVIDER = 'DomainConfigProvider';
 
 	public function __construct() {
 		parent::__construct( 'LDAPProvider' );

--- a/src/DomainConfigProvider/InlinePHPArray.php
+++ b/src/DomainConfigProvider/InlinePHPArray.php
@@ -1,0 +1,44 @@
+<?php
+/*
+ * Copyright (C) 2018
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+namespace MediaWiki\Extension\LDAPProvider\DomainConfigProvider;
+
+use MediaWiki\Extension\LDAPProvider\IDomainConfigProvider;
+
+class InlinePHPArray implements IDomainConfigProvider {
+
+	private $configArray = [];
+
+	/**
+	 *
+	 * @param array $config
+	 */
+	public function __construct( $config ) {
+		$this->configArray = $config;
+	}
+
+	/**
+	 *
+	 * @return array
+	 */
+	public function getConfigArray() {
+		return  $this->configArray;
+	}
+}

--- a/src/DomainConfigProvider/LocalJSONFile.php
+++ b/src/DomainConfigProvider/LocalJSONFile.php
@@ -1,0 +1,76 @@
+<?php
+/*
+ * Copyright (C) 2018
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+namespace MediaWiki\Extension\LDAPProvider\DomainConfigProvider;
+
+use MediaWiki\Extension\LDAPProvider\IDomainConfigProvider;
+use MediaWiki\Extension\LDAPProvider\Config;
+use MWException;
+use FormatJson;
+
+class LocalJSONFile implements IDomainConfigProvider {
+
+	/**
+	 *
+	 * @var array
+	 */
+	private $configArray = [];
+
+	/**
+	 *
+	 * @param string $jsonFilePath
+	 */
+	public function __construct( $jsonFilePath ) {
+		if ( !is_readable( $jsonFilePath ) ) {
+			throw new MWException(
+				wfMessage( 'ldapprovider-domain-config-not-found' )->params( $jsonFilePath )->plain()
+			);
+		}
+
+		$this->configArray = FormatJson::decode(
+			file_get_contents( $jsonFilePath ),
+			true
+		);
+
+		if ( $this->configArray === false
+			|| count( $this->configArray ) === 0 ) {
+
+			throw new MWException(
+				"Could not parse configuration file '$jsonFilePath'!"
+			);
+		}
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getConfigArray() {
+		return $this->configArray;
+	}
+
+	/**
+	 *
+	 * @param Config $ldapConfig
+	 * @return JSonfile
+	 */
+	public static function newInstance( $ldapConfig ) {
+		return new self( $ldapConfig->get( Config::DOMAIN_CONFIGS ) );
+	}
+}

--- a/src/IDomainConfigProvider.php
+++ b/src/IDomainConfigProvider.php
@@ -1,0 +1,29 @@
+<?php
+/*
+ * Copyright (C) 2018
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+namespace MediaWiki\Extension\LDAPProvider;
+
+interface IDomainConfigProvider {
+
+	/**
+	 * @return array
+	 */
+	public function getConfigArray();
+}

--- a/tests/phpunit/DomainConfigFactoryTest.php
+++ b/tests/phpunit/DomainConfigFactoryTest.php
@@ -4,6 +4,7 @@ namespace MediaWiki\Extension\LDAPProvider\Tests;
 
 use MediaWiki\Extension\LDAPProvider\DomainConfigFactory;
 use MediaWiki\Extension\LDAPProvider\ClientConfig;
+use MediaWiki\Extension\LDAPProvider\DomainConfigProvider\LocalJSONFile;
 
 class DomainConfigFactoryTest extends \MediaWikiTestCase {
 
@@ -39,7 +40,9 @@ class DomainConfigFactoryTest extends \MediaWikiTestCase {
 	 * @return DomainConfigFactory
 	 */
 	protected function makeDomainConfigFactory() {
-		return new DomainConfigFactory( __DIR__ . '/data/testconfig.json' );
+		return new DomainConfigFactory(
+			new LocalJSONFile( __DIR__ . '/data/testconfig.json' )
+		);
 	}
 
 }


### PR DESCRIPTION
By abstracting the source of the configuration we can have "dynamic"
configurations.

For example in `LocalSettings.php` one can now use

    $LDAPProviderDomainConfigProvider = function( $ldapConfig ) {
      return new \MediaWiki\Extension\LDAPProvider\DomainConfigProvider\InlinePHPArray( [
        'HW' => [
          'connection' => [
            'port' => 8765
          ]
        ]
      ] );
    };

Hallo Welt! GmbH needs something like this, because some of our customers have
multiple wiki instances that all use the same codebase. LDAP configuration
depends on the wikiId.
Those instances can be created dynamically therefore a static configuration
file will not work for us.